### PR TITLE
Add execution context based tracing

### DIFF
--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_tracer.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_tracer.rb
@@ -13,6 +13,12 @@ module OpenTelemetry
         # GraphQLTracer contains the OpenTelemetry tracer implementation compatible with
         # the GraphQL tracer API
         class GraphQLTracer < ::GraphQL::Tracing::PlatformTracing
+          TRACE_PHASE_TO_TYPE = {
+            field: :enable_platform_field,
+            authorized: :enable_platform_authorized,
+            resolve_type: :enable_platform_resolve_type
+          }.freeze
+
           self.platform_keys = {
             'lex' => 'graphql.lex',
             'parse' => 'graphql.parse',
@@ -43,20 +49,14 @@ module OpenTelemetry
           end
 
           def platform_field_key(type, field)
-            return unless config[:enable_platform_field]
-
             "#{type.graphql_name}.#{field.graphql_name}"
           end
 
           def platform_authorized_key(type)
-            return unless config[:enable_platform_authorized]
-
             "#{type.graphql_name}.authorized"
           end
 
           def platform_resolve_type_key(type)
-            return unless config[:enable_platform_resolve_type]
-
             "#{type.graphql_name}.resolve_type"
           end
 
@@ -70,6 +70,16 @@ module OpenTelemetry
             GraphQL::Instrumentation.instance.config
           end
 
+          def platform_key_enabled?(ctx, key)
+            return false unless config[key]
+
+            ns = ctx.namespace(:opentelemetry)
+            return true if ns.empty? # restores original behavior so that keys are returned if tracing is not set in context.
+            return false unless ns.key?(key) && ns[key]
+
+            true
+          end
+
           def attributes_for(key, data)
             attributes = {}
             case key
@@ -79,6 +89,18 @@ module OpenTelemetry
               attributes['query_string'] = data[:query].query_string
             end
             attributes
+          end
+
+          def cached_platform_key(ctx, key, trace_phase)
+            cache = ctx.namespace(self.class)[:platform_key_cache] ||= {}
+
+            cache.fetch(key) do
+              cache[key] = begin
+                return unless platform_key_enabled?(ctx, TRACE_PHASE_TO_TYPE.fetch(trace_phase))
+
+                yield
+              end
+            end
           end
         end
       end

--- a/instrumentation/graphql/opentelemetry-instrumentation-graphql.gemspec
+++ b/instrumentation/graphql/opentelemetry-instrumentation-graphql.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'bundler', '>= 1.17'
-  spec.add_development_dependency 'graphql', '~> 1.11'
+  spec.add_development_dependency 'graphql', '~> 1.13'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
   spec.add_development_dependency 'opentelemetry-test-helpers'


### PR DESCRIPTION
`graphql-ruby` now passes in the `trace_phase` to `cached_platform_key` within `PlatformTracer` [commit](https://github.com/rmosolgo/graphql-ruby/commit/f4d99f692d393cf5a1abbfe0e9bb61972ffba37f).

This allows us to check the a platform key (`enable_platform_field`, `enable_platform_authorized` or `enable_platform_resolve_type` is enabled within the query execution context, thus allowing us to trace specifc requests.

This PR implement query execution based tracing.

 