### PR TITLE
feat: Add GraphQL query context based tracing

### DIFF
--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_tracer.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/tracers/graphql_tracer.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'opentelemetry'
+
+module OpenTelemetry
+  module Instrumentation
+    module GraphQL
+      module Tracers
+        # GraphQLTracer contains the OpenTelemetry tracer implementation compatible with
+        # the GraphQL tracer API
+        class GraphQLTracer < ::GraphQL::Tracing::PlatformTracing
+          TRACE_PHASE_TO_TYPE = {
+            field: :enable_platform_field,
+            authorized: :enable_platform_authorized,
+            resolve_type: :enable_platform_resolve_type
+          }.freeze
+
+          self.platform_keys = {
+            'lex' => 'graphql.lex',
+            'parse' => 'graphql.parse',
+            'validate' => 'graphql.validate',
+            'analyze_query' => 'graphql.analyze_query',
+            'analyze_multiplex' => 'graphql.analyze_multiplex',
+            'execute_query' => 'graphql.execute_query',
+            'execute_query_lazy' => 'graphql.execute_query_lazy',
+            'execute_multiplex' => 'graphql.execute_multiplex'
+          }
+
+          def platform_trace(platform_key, key, data)
+            return yield if platform_key.nil?
+
+            tracer.in_span(platform_key, attributes: attributes_for(key, data)) do |span|
+              yield.tap do |response|
+                errors = response[:errors]&.compact&.map { |e| e.to_h }&.to_json if key == 'validate'
+                unless errors.nil?
+                  span.add_event(
+                    'graphql.validation.error',
+                    attributes: {
+                      'message' => errors
+                    }
+                  )
+                end
+              end
+            end
+          end
+
+          def platform_field_key(type, field)
+            "#{type.graphql_name}.#{field.graphql_name}"
+          end
+
+          def platform_authorized_key(type)
+            "#{type.graphql_name}.authorized"
+          end
+
+          def platform_resolve_type_key(type)
+            "#{type.graphql_name}.resolve_type"
+          end
+
+          private
+
+          def tracer
+            GraphQL::Instrumentation.instance.tracer
+          end
+
+          def config
+            GraphQL::Instrumentation.instance.config
+          end
+
+          def platform_key_enabled?(ctx, key)
+            return false unless config[key]
+
+            ns = ctx.namespace(:opentelemetry)
+            return true if ns.empty? # restores original behavior so that keys are returned if tracing is not set in context.
+            return false unless ns.key?(key) && ns[key]
+
+            true
+          end
+
+          def attributes_for(key, data)
+            attributes = {}
+            case key
+            when 'execute_query'
+              attributes['selected_operation_name'] = data[:query].selected_operation_name if data[:query].selected_operation_name
+              attributes['selected_operation_type'] = data[:query].selected_operation.operation_type
+              attributes['query_string'] = data[:query].query_string
+            end
+            attributes
+          end
+
+          def cached_platform_key(ctx, key, trace_phase)
+            cache = ctx.namespace(self.class)[:platform_key_cache] ||= {}
+
+            cache.fetch(key) do
+              cache[key] = begin
+                return unless platform_key_enabled?(ctx, TRACE_PHASE_TO_TYPE.fetch(trace_phase))
+
+                yield
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/instrumentation/graphql/opentelemetry-instrumentation-graphql.gemspec
+++ b/instrumentation/graphql/opentelemetry-instrumentation-graphql.gemspec
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+lib = File.expand_path('lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'opentelemetry/instrumentation/graphql/version'
+
+Gem::Specification.new do |spec|
+  spec.name        = 'opentelemetry-instrumentation-graphql'
+  spec.version     = OpenTelemetry::Instrumentation::GraphQL::VERSION
+  spec.authors     = ['OpenTelemetry Authors']
+  spec.email       = ['cncf-opentelemetry-contributors@lists.cncf.io']
+
+  spec.summary     = 'GraphQL instrumentation for the OpenTelemetry framework'
+  spec.description = 'GraphQL instrumentation for the OpenTelemetry framework'
+  spec.homepage    = 'https://github.com/open-telemetry/opentelemetry-ruby'
+  spec.license     = 'Apache-2.0'
+
+  spec.files = ::Dir.glob('lib/**/*.rb') +
+               ::Dir.glob('*.md') +
+               ['LICENSE', '.yardopts']
+  spec.require_paths = ['lib']
+  spec.required_ruby_version = '>= 2.6.0'
+
+  spec.add_dependency 'opentelemetry-api', '~> 1.0'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.21.0'
+
+  spec.add_development_dependency 'appraisal', '~> 2.2.0'
+  spec.add_development_dependency 'bundler', '>= 1.17'
+  spec.add_development_dependency 'graphql', '~> 1.13'
+  spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency 'opentelemetry-sdk', '~> 1.1'
+  spec.add_development_dependency 'opentelemetry-test-helpers'
+  spec.add_development_dependency 'rake', '~> 12.3.3'
+  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'simplecov', '~> 0.17.1'
+  spec.add_development_dependency 'webmock', '~> 3.7.6'
+  spec.add_development_dependency 'yard', '~> 0.9'
+  spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
+
+  if spec.respond_to?(:metadata)
+    spec.metadata['changelog_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-graphql/v#{OpenTelemetry::Instrumentation::GraphQL::VERSION}/file.CHANGELOG.html"
+    spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/tree/main/instrumentation/graphql'
+    spec.metadata['bug_tracker_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/issues'
+    spec.metadata['documentation_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-graphql/v#{OpenTelemetry::Instrumentation::GraphQL::VERSION}"
+  end
+end

--- a/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_tracer_test.rb
+++ b/instrumentation/graphql/test/instrumentation/graphql/tracers/graphql_tracer_test.rb
@@ -1,0 +1,333 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+require_relative '../../../../lib/opentelemetry/instrumentation/graphql'
+require_relative '../../../../lib/opentelemetry/instrumentation/graphql/tracers/graphql_tracer'
+
+describe OpenTelemetry::Instrumentation::GraphQL::Tracers::GraphQLTracer do
+  let(:graphql_tracer) { OpenTelemetry::Instrumentation::GraphQL::Tracers::GraphQLTracer }
+  let(:instrumentation) { OpenTelemetry::Instrumentation::GraphQL::Instrumentation.instance }
+  let(:exporter) { EXPORTER }
+  let(:spans) { exporter.finished_spans }
+  let(:span_names) { spans.map(&:name) }
+  let(:config) { {} }
+
+  let(:query_string) do
+    <<-GRAPHQL
+      query($id: Int!){
+        simpleField
+        resolvedField(id: $id) {
+          originalValue
+          uppercasedValue
+        }
+      }
+    GRAPHQL
+  end
+
+  before do
+    exporter.reset
+    instrumentation.install(config)
+  end
+
+  after do
+    # Force re-install of instrumentation
+    instrumentation.instance_variable_set(:@installed, false)
+
+    # Reset various instance variables to clear state between tests
+    ::GraphQL::Schema.instance_variable_set(:@own_tracers, [])
+
+    # Reseting @graphql_definition is needed for tests running against version `1.9.x`
+    SomeOtherGraphQLAppSchema.remove_instance_variable(:@graphql_definition) if SomeOtherGraphQLAppSchema.instance_variable_defined?(:@graphql_definition)
+    SomeGraphQLAppSchema.remove_instance_variable(:@graphql_definition) if SomeGraphQLAppSchema.instance_variable_defined?(:@graphql_definition)
+  end
+
+  describe '#platform_trace' do
+    it 'traces platform keys' do
+      result = SomeGraphQLAppSchema.execute(query_string, variables: { 'id': 1 })
+
+      graphql_tracer.platform_keys.each do |_key, value|
+        span = spans.find { |s| s.name == value }
+        _(span).wont_be_nil
+      end
+
+      _(result.to_h['data']).must_equal('simpleField' => 'Hello.', 'resolvedField' => { 'originalValue' => 'testing=1', 'uppercasedValue' => 'TESTING=1' })
+    end
+
+    it 'only traces known platform keys' do
+      graphql_tracer.new.trace('unknown_execute_key', nil) {}
+
+      _(spans).must_be(:empty?)
+    end
+
+    it 'includes operation attributes for execute_query' do
+      expected_attributes = {
+        'selected_operation_name' => 'SimpleQuery',
+        'selected_operation_type' => 'query',
+        'query_string' => 'query SimpleQuery{ simpleField }'
+      }
+
+      SomeGraphQLAppSchema.execute('query SimpleQuery{ simpleField }')
+
+      span = spans.find { |s| s.name == 'graphql.execute_query' }
+      _(span).wont_be_nil
+      _(span.attributes.to_h).must_equal(expected_attributes)
+    end
+
+    it 'omits nil attributes for execute_query' do
+      expected_attributes = {
+        'selected_operation_type' => 'query',
+        'query_string' => '{ simpleField }'
+      }
+
+      SomeGraphQLAppSchema.execute('{ simpleField }')
+
+      span = spans.find { |s| s.name == 'graphql.execute_query' }
+      _(span).wont_be_nil
+      _(span.attributes.to_h).must_equal(expected_attributes)
+    end
+
+    describe 'when a set of schemas is provided' do
+      let(:config) { { schemas: [SomeOtherGraphQLAppSchema] } }
+
+      after do
+        # Reset various instance variables to clear state between tests
+        SomeOtherGraphQLAppSchema.instance_variable_set(:@own_tracers, [])
+        SomeOtherGraphQLAppSchema.instance_variable_set(:@own_plugins, SomeOtherGraphQLAppSchema.plugins[0..1])
+      end
+
+      it 'traces the provided schemas' do
+        SomeOtherGraphQLAppSchema.execute('query SimpleQuery{ __typename }')
+
+        graphql_tracer.platform_keys.each do |_key, value|
+          span = spans.find { |s| s.name == value }
+          _(span).wont_be_nil
+        end
+
+        _(spans.size).must_equal(8)
+      end
+
+      it 'does not trace all schemas' do
+        SomeGraphQLAppSchema.execute('query SimpleQuery{ __typename }')
+
+        _(spans).must_be(:empty?)
+      end
+    end
+
+    describe 'when platform_field is enabled' do
+      let(:config) { { enable_platform_field: true } }
+
+      it 'traces execute_field' do
+        SomeGraphQLAppSchema.execute(query_string, variables: { 'id': 1 })
+
+        span = spans.find { |s| s.name == 'Query.resolvedField' }
+        _(span).wont_be_nil
+      end
+    end
+
+    describe 'when platform_authorized is enabled' do
+      let(:config) { { enable_platform_authorized: true } }
+
+      it 'traces .authorized' do
+        skip unless supports_authorized_and_resolved_types?
+        SomeGraphQLAppSchema.execute(query_string, variables: { 'id': 1 })
+
+        span = spans.find { |s| s.name == 'Query.authorized' }
+        _(span).wont_be_nil
+
+        span = spans.find { |s| s.name == 'SlightlyComplex.authorized' }
+        _(span).wont_be_nil
+      end
+    end
+
+    describe 'when platform_resolve_type is enabled' do
+      let(:config) { { enable_platform_resolve_type: true } }
+
+      it 'traces .resolve_type' do
+        skip unless supports_authorized_and_resolved_types?
+        SomeGraphQLAppSchema.execute('{ vehicle { __typename } }')
+
+        span = spans.find { |s| s.name == 'Vehicle.resolve_type' }
+        _(span).wont_be_nil
+      end
+    end
+
+    it 'traces validate with events' do
+      SomeGraphQLAppSchema.execute(
+        <<-GRAPHQL
+          {
+            nonExistentField
+          }
+        GRAPHQL
+      )
+      span = spans.find { |s| s.name == 'graphql.validate' }
+      event = span.events.find { |e| e.name == 'graphql.validation.error' }
+      _(event.attributes['message']).must_equal(
+        "[{\"message\":\"Field 'nonExistentField' doesn't exist on type 'Query'\",\"locations\":[{\"line\":2,\"column\":13}],\"path\":[\"query\",\"nonExistentField\"],\"extensions\":{\"code\":\"undefinedField\",\"typeName\":\"Query\",\"fieldName\":\"nonExistentField\"}}]"
+      )
+    end
+
+    describe 'tracing based on query execution context' do
+      let(:query) { GraphQL::Query.new(SomeGraphQLAppSchema, '{ vehicle { __typename } }') }
+
+      describe 'keys are enabled in config' do
+        let(:config) { { enable_platform_field: true, enable_platform_authorized: true, enable_platform_resolve_type: true } }
+
+        it 'captures the keys when tracing is enabled in config and in query execution context' do
+          query.context.namespace(:opentelemetry)[:enable_platform_field] = true
+          query.context.namespace(:opentelemetry)[:enable_platform_authorized] = true
+          query.context.namespace(:opentelemetry)[:enable_platform_resolve_type] = true
+          query.result
+
+          assert span_names.include?('Query.authorized')
+          assert span_names.include?('Query.vehicle')
+          assert span_names.include?('Vehicle.resolve_type')
+          assert span_names.include?('Car.authorized')
+        end
+
+        it 'does not capture the keys when tracing is disabled in query execution context' do
+          query.context.namespace(:opentelemetry)[:enable_platform_field] = false
+          query.context.namespace(:opentelemetry)[:enable_platform_authorized] = false
+          query.context.namespace(:opentelemetry)[:enable_platform_resolve_type] = false
+          query.result
+
+          refute span_names.include?('Query.authorized')
+          refute span_names.include?('Query.vehicle')
+          refute span_names.include?('Vehicle.resolve_type')
+          refute span_names.include?('Car.authorized')
+        end
+
+        it 'captures the keys when tracing config is not set in query execution context' do
+          query.result
+
+          assert span_names.include?('Query.authorized')
+          assert span_names.include?('Query.vehicle')
+          assert span_names.include?('Vehicle.resolve_type')
+          assert span_names.include?('Car.authorized')
+        end
+      end
+
+      describe 'keys are disabled in config' do
+        let(:config) { { enable_platform_field: false, enable_platform_authorized: false, enable_platform_resolve_type: false } }
+
+        it 'does not capture the keys when tracing is enabled in query execution context' do
+          query.context.namespace(:opentelemetry)[:enable_platform_field] = true
+          query.context.namespace(:opentelemetry)[:enable_platform_authorized] = true
+          query.context.namespace(:opentelemetry)[:enable_platform_resolve_type] = true
+          query.result
+
+          refute span_names.include?('Query.authorized')
+          refute span_names.include?('Query.vehicle')
+          refute span_names.include?('Vehicle.resolve_type')
+          refute span_names.include?('Car.authorized')
+        end
+
+        it 'does not capture the keys when tracing config is missing in query execution context' do
+          query.result
+
+          refute span_names.include?('Query.authorized')
+          refute span_names.include?('Query.vehicle')
+          refute span_names.include?('Vehicle.resolve_type')
+          refute span_names.include?('Car.authorized')
+        end
+
+        it 'does not capture the keys when tracing is disabled in query execution context' do
+          query.context.namespace(:opentelemetry)[:enable_platform_field] = false
+          query.context.namespace(:opentelemetry)[:enable_platform_authorized] = false
+          query.context.namespace(:opentelemetry)[:enable_platform_resolve_type] = false
+          query.result
+
+          refute span_names.include?('Query.authorized')
+          refute span_names.include?('Query.vehicle')
+          refute span_names.include?('Vehicle.resolve_type')
+          refute span_names.include?('Car.authorized')
+        end
+      end
+    end
+  end
+
+  private
+
+  # These fields are only supported as of version 1.10.0
+  # https://github.com/rmosolgo/graphql-ruby/blob/v1.10.0/CHANGELOG.md#new-features-1
+  def supports_authorized_and_resolved_types?
+    Gem.loaded_specs['graphql'].version >= Gem::Version.new('1.10.0')
+  end
+
+  module Old
+    Truck = Struct.new(:price)
+  end
+
+  module Vehicle
+    include GraphQL::Schema::Interface
+  end
+
+  class Car < ::GraphQL::Schema::Object
+    implements Vehicle
+
+    field :price, Integer, null: true
+  end
+
+  class SlightlyComplexType < ::GraphQL::Schema::Object
+    field :uppercased_value, String, null: false
+    field :original_value, String, null: false
+
+    def uppercased_value
+      object.original_value.upcase
+    end
+  end
+
+  class SimpleResolver < ::GraphQL::Schema::Resolver
+    type SlightlyComplexType, null: false
+
+    argument :id, Integer, required: true
+
+    def resolve(id:)
+      Struct.new(:original_value).new("testing=#{id}")
+    end
+  end
+
+  class QueryType < ::GraphQL::Schema::Object
+    field :simple_field, String, null: false
+    field :resolved_field, resolver: SimpleResolver
+
+    # Required for testing resolve_type
+    field :vehicle, Vehicle, null: true
+
+    def vehicle
+      Old::Truck.new(50)
+    end
+
+    def simple_field
+      'Hello.'
+    end
+  end
+
+  class OtherQueryType < ::GraphQL::Schema::Object
+    field :simple_field, String, null: false
+    def simple_field
+      'Hello.'
+    end
+  end
+
+  class SomeOtherGraphQLAppSchema < ::GraphQL::Schema
+    query(::OtherQueryType)
+    use GraphQL::Execution::Interpreter
+    use GraphQL::Analysis::AST
+  end
+
+  class SomeGraphQLAppSchema < ::GraphQL::Schema
+    query(::QueryType)
+    use GraphQL::Execution::Interpreter
+    use GraphQL::Analysis::AST
+    orphan_types Car
+
+    def self.resolve_type(_type, _obj, _ctx)
+      Car
+    end
+  end
+end


### PR DESCRIPTION
graphql-ruby now passes in the `trace_phase` to `cached_platform_key` within `PlatformTracer`.

This allows us to check the a platform key (`enable_platform_field`, `enable_platform_authorized` or `enable_platform_resolve_type` is enabled within the query execution context, thus allowing us to trace specifc requests.

This PR implement query execution based tracing.
